### PR TITLE
Format links for slack

### DIFF
--- a/src/format-github-src-link.js
+++ b/src/format-github-src-link.js
@@ -1,9 +1,6 @@
-const { mdLink } = require('./markdown')
 const { pipe } = require('ramda')
 
-const formatGithubSrcUrl = (name) => 
+const formatGithubSrcLink = (name) => 
   `https://github.com/ramda/ramda/blob/master/src/${name}.js`
-
-const formatGithubSrcLink = pipe(formatGithubSrcUrl, mdLink('Ⓢ'))
 
 module.exports = formatGithubSrcLink

--- a/src/format-github-src-link.js
+++ b/src/format-github-src-link.js
@@ -1,6 +1,6 @@
 const { pipe } = require('ramda')
 
-const formatGithubSrcLink = (name) => 
-  `https://github.com/ramda/ramda/blob/master/src/${name}.js`
+const formatGithubSrcLink = (name, sig) => 
+  [sig, `https://github.com/ramda/ramda/blob/master/src/${name}.js`]
 
 module.exports = formatGithubSrcLink

--- a/src/format-ramda-docs-link.js
+++ b/src/format-ramda-docs-link.js
@@ -1,4 +1,4 @@
-const { mdPre, mdLink } = require('./markdown')
+const { mdPre } = require('./markdown')
 const DOCS_URL = 'http://ramdajs.com/docs/'
 
 const formatRamdaDocsLink = (name, sig) => 

--- a/src/format-ramda-docs-link.js
+++ b/src/format-ramda-docs-link.js
@@ -1,7 +1,7 @@
 const { mdPre, mdLink } = require('./markdown')
 const DOCS_URL = 'http://ramdajs.com/docs/'
 
-const formatRamdaDocsLink = (name, sig) =>
-  mdLink(mdPre(`R.${name} ∷ ${sig.replace(/->/g, '→')}`), `${DOCS_URL}#${name}`)
+const formatRamdaDocsLink = (name, sig) => 
+  [mdPre(`R.${name} ∷ ${sig.replace(/->/g, '→')}`), `${DOCS_URL}#${name}`]
 
 module.exports = formatRamdaDocsLink

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ module.exports = (bot) =>
             fnDoc =>
               res.reply(trim(unwords([
                 (user ? mention(user) : ''),
-                pipe(formatRamdaDocsLink(fnDoc.name, fnDoc.sig), apply(mdLinkFn)),
-                pipe(formatGithubSrcLink(fnDoc.name), mdLinkFn('Ⓢ'))
+                pipe(formatRamdaDocsLink, apply(mdLinkFn))(fnDoc.name, fnDoc.sig),
+                pipe(formatGithubSrcLink, apply(mdLinkFn))(fnDoc.name, 'Ⓢ')
               ]))))
   })

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@
 const getRamdaFunctionDocs = require('./get-ramda-function-docs')
 const formatRamdaDocsLink = require('./format-ramda-docs-link')
 const formatGithubSrcLink = require('./format-github-src-link')
-const { join, trim } = require('ramda')
+const {mdLink, mdLinkSlack } = require('./markdown')
+const {apply, pipe, join, trim} = require('ramda')
 
 const unwords = join(' ')
 const mention = (user) => `@${user}`
@@ -13,12 +14,18 @@ module.exports = (bot) =>
   bot.hear(/^`?R\.([a-z]+)`?(?: @(\w[\w-]+))?\s?$/i, (res) => {
     const [_, fnName, user] = res.match
 
+    if (bot.adapterName === "slack") {
+      const mdLinkFn = mdLinkSlack;
+    } else {
+      const mdLinkFn = mdLink;
+    }
+
     getRamdaFunctionDocs(fnName)
       .fork(err => res.reply(err),
             fnDoc =>
               res.reply(trim(unwords([
                 (user ? mention(user) : ''),
-                formatRamdaDocsLink(fnDoc.name, fnDoc.sig),
-                formatGithubSrcLink(fnDoc.name)
+                pipe(formatRamdaDocsLink(fnDoc.name, fnDoc.sig), apply(mdLinkFn)),
+                pipe(formatGithubSrcLink(fnDoc.name), mdLinkFn('Ⓢ'))
               ]))))
   })

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -2,6 +2,7 @@ const { curry } = require('ramda')
 
 const wrap = curry((x, s) => x + s + x)
 exports.mdLink = curry((text, url) => `[${text}](${url})`)
+exports.mdLinkSlack = curry((text, url) => `<${url}|${text}>`)
 exports.mdBold = wrap('**')
 exports.mdStrike = wrap('~~')
 exports.mdPre = wrap('`')

--- a/test/format-github-src-link.js
+++ b/test/format-github-src-link.js
@@ -1,15 +1,15 @@
-const { pipe } = require('ramda')
+const { apply, pipe } = require('ramda')
 const assert = require('assert')
 const { mdLink, mdLinkSlack } = require('../src/markdown');
 const formatGithubSrcLink = require('../src/format-github-src-link')
 
 describe('formatGithubSrcLink', () => {
   it('formats a link', () => {
-    assert.equal(pipe(formatGithubSrcLink, mdLink('Ⓢ'))('prop'),
+    assert.equal(pipe(formatGithubSrcLink, apply(mdLink))('prop', 'Ⓢ'),
         '[Ⓢ](https://github.com/ramda/ramda/blob/master/src/prop.js)');
   })
   it('formats a link for slack', () => {
-    assert.equal(pipe(formatGithubSrcLink, mdLinkSlack('Ⓢ'))('prop'),
+    assert.equal(pipe(formatGithubSrcLink, apply(mdLinkSlack))('prop', 'Ⓢ'),
         '<https://github.com/ramda/ramda/blob/master/src/prop.js|Ⓢ>');
   })
 })

--- a/test/format-github-src-link.js
+++ b/test/format-github-src-link.js
@@ -1,9 +1,15 @@
+const { pipe } = require('ramda')
 const assert = require('assert')
+const { mdLink, mdLinkSlack } = require('../src/markdown');
 const formatGithubSrcLink = require('../src/format-github-src-link')
 
 describe('formatGithubSrcLink', () => {
   it('formats a link', () => {
-    assert.equal(formatGithubSrcLink('prop'),
-                 '[Ⓢ](https://github.com/ramda/ramda/blob/master/src/prop.js)')
+    assert.equal(pipe(formatGithubSrcLink, mdLink('Ⓢ'))('prop'),
+        '[Ⓢ](https://github.com/ramda/ramda/blob/master/src/prop.js)');
+  })
+  it('formats a link for slack', () => {
+    assert.equal(pipe(formatGithubSrcLink, mdLinkSlack('Ⓢ'))('prop'),
+        '<https://github.com/ramda/ramda/blob/master/src/prop.js|Ⓢ>');
   })
 })

--- a/test/format-ramda-docs-link.js
+++ b/test/format-ramda-docs-link.js
@@ -1,9 +1,15 @@
 const assert = require('assert')
 const formatRamdaDocsLink = require('../src/format-ramda-docs-link')
+const { apply, pipe } = require("ramda");
+const { mdLinkSlack, mdLink } = require('../src/markdown');
 
 describe('formatRamdaDocsLink', () => {
   it('formats a link', () => {
-    assert.equal(formatRamdaDocsLink('prop', 's -> {s: a} -> a | Undefined'),
-                 '[`R.prop ∷ s → {s: a} → a | Undefined`](http://ramdajs.com/docs/#prop)')
+    assert.equal(pipe(formatRamdaDocsLink, apply(mdLink))('prop', 's -> {s: a} -> a | Undefined'),
+        '[`R.prop ∷ s → {s: a} → a | Undefined`](http://ramdajs.com/docs/#prop)')
+  })
+  it('formats a link for slack', () => {
+    assert.equal(pipe(formatRamdaDocsLink, apply(mdLinkSlack))('prop', 's -> {s: a} -> a | Undefined'),
+        '<http://ramdajs.com/docs/#prop|`R.prop ∷ s → {s: a} → a | Undefined`>');
   })
 })


### PR DESCRIPTION
Slack has it's own way of formatting links, so I added a function to do that.

This pulls functionality out of the abstraction, but I couldn't think of a better way to do it.